### PR TITLE
Expose currentViewScope on overmind.shared

### DIFF
--- a/src/overmind.js
+++ b/src/overmind.js
@@ -176,6 +176,7 @@ angular.module('overmind').directive('overmind', ["$location", "$route", functio
         var link = $compile(currentView.parent().contents());
 
         currentViewScope = currentAppScope.$new();
+        overmind.shared.currentViewScope = currentViewScope;
         if (currentRoute.controller) {
           locals.$scope = currentViewScope;
           var $controller = currentAppInjector.get('$controller');


### PR DESCRIPTION
When turning off Angular's debug info, there's no way to easily get the scope for the "#current-view" div.  (Though it should be the only child of the overmindScope, this provides a more safe way to obtain the currentViewScope.)