### PR TITLE
Fixes an IE 8 error

### DIFF
--- a/src/overmind.js
+++ b/src/overmind.js
@@ -118,7 +118,7 @@ angular.module('overmind').directive('overmind', ["$location", "$route", functio
         // determine the app (if any) to bootstrap or use default
         var overmind = angular.module('overmind');
         var match = $location.path().match(/\/\w+/) || [];
-        var app = overmind.apps[match[0]] || overmind.default;
+        var app = overmind.apps[match[0]] || overmind["default"];
 
         // if the app is registered and is different from the current app, bootstrap it
         if (app && app !== currentlyBootstrapped){


### PR DESCRIPTION
IE 8 throws an error when referencing overmind.default. Accessing the "default" key with bracket notation fixes it.

Not sure if you're wanting to support IE 8, but this is a pretty minor change that allows Overmind to run in IE 8.