### PR TITLE
Fix ReferenceError from incomplete refactor

### DIFF
--- a/src/overmind.js
+++ b/src/overmind.js
@@ -181,7 +181,7 @@ angular.module('overmind').directive('overmind', ["$location", "$route", functio
           var $controller = currentAppInjector.get('$controller');
           var controller = $controller(currentRoute.controller, locals);
           if (currentRoute.controllerAs) {
-            currentViewScope[current.controllerAs] = controller;
+            currentViewScope[currentRoute.controllerAs] = controller;
           }
           currentView.data('$ngControllerController', controller);
           currentView.children().data('$ngControllerController', controller);


### PR DESCRIPTION
[Commit b5fe47e](https://github.com/geddski/overmind/commit/b5fe47e215692d172ba6b5f67be794e977f08313#diff-6d19ac297f4f828c0cfcbb5441deb6c8R174) renamed `current` to `currentRoute` but left behind one usage of `current`.